### PR TITLE
Expose Level on Logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -85,6 +85,11 @@ func (l Logger) With(options ...LoggerOption) Logger {
 	return l
 }
 
+// GetLevel returns the current log level.
+func (l *Logger) GetLevel() LogLevel {
+	return l.level
+}
+
 // Debug logs a new message with debug level.
 func (l *Logger) Debug(message string, fields ...Field) {
 	l.logEvent(DebugLevel, message, nil, fields)


### PR DESCRIPTION
So that users can determine the current log level without maintaining it outside of the logger.

This is related to #3 where I'd like to avoid calculating timings (using `time.Since()`) when the debug message would be dropped anyway.

I'd considered making a getter like `GetLevel`, but it seemed overkill since it's just an opaque type, but this does allow the user to set it directly (without using the `LogOption`).