### PR TITLE
Expose fields from Event

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,26 @@
+package rz
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvent_Fields(t *testing.T) {
+	fields := map[string]interface{}{
+		"hostname": "localhost",
+		"latency":  3000.0,
+	}
+	event := newEvent(nil, DebugLevel)
+
+	for key, value := range fields {
+		event.Append(Any(key, value))
+	}
+
+	got, err := event.Fields()
+	if err != nil {
+		t.Fatalf("Event.Fields() returned error: %s", err)
+	}
+	if !reflect.DeepEqual(fields, got) {
+		t.Errorf("Event.Fields() returned %+v, want %+v", got, fields)
+	}
+}


### PR DESCRIPTION
We were thinking of using`LevelHook` to send all logs at the `LevelError` to our exception tracking service (Sentry) generating the metadata from the structured log fields, but there does not appear to be a way to get the fields from inside of a log hook.

For example:

```go
	hook := rz.HookFunc(func(e *rz.Event, level LogLevel, msg string) {
		if level > rz.ErrorLevel && level < rz.NoLevel {
			packet := &raven.Packet{
				Message: "Hand-crafted event",
				Extra:   e.Fields(), // doesn't exist
			}
			raven.Capture(packet)
		}
	})
```

This is implemented in a rather expensive way (similar to the alternative log formatters), but I couldn't determine an easier way to do it. It suffices for our use case which should be a rare event. I tried to document this shortcoming.